### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/CHNAGELOG.md
+++ b/CHNAGELOG.md
@@ -1,4 +1,4 @@
-#Change Log
+# Change Log
 Version 1.0.2 *(2015-09-25)*
 ----------------------------
 * fix bug:some method invalid in built-in dialog

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-#FlycoDialog-Master
+# FlycoDialog-Master
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-FlycoDialog--Matser-green.svg?style=flat)](https://android-arsenal.com/details/1/2430)
-####[中文版](https://github.com/H07000223/FlycoDialog_Master/blob/master/README_CN.md)
+#### [中文版](https://github.com/H07000223/FlycoDialog_Master/blob/master/README_CN.md)
 An Android Dialog Lib simplify customization. Supprot 2.2+.
 
-##Features
+## Features
 - [Built-in Dialog, convenient to use](#Built-in Dialog)
 - [Abundant Built-in Animations, convenient to use](#Abundant Built-in Animations)
 - [Qucik Customize Dialog](#Qucik Customize Dialog)
 - [Qucik Customize Popup](#Qucik Customize Popup)
 - [Support Customize Dialog Animation](#Customize Dialog Animation)
 
-####[DemoApk Download](http://fir.im/mj9p)
+#### [DemoApk Download](http://fir.im/mj9p)
 
 ## <a name="Built-in Dialog"></a>Built-in Dialog
 |Dialog|Description|ScreenShot|gif
@@ -29,7 +29,7 @@ An Android Dialog Lib simplify customization. Supprot 2.2+.
 | ActionSheetDialog | Default | <img src="https://github.com/H07000223/FlycoDialog_Master/blob/master/screenshot/action_sheet_1.png" width="250"> |[gif](https://github.com/H07000223/FlycoDialog_Master/blob/master/gif/preview_12.gif)
 | ActionSheetDialog | No Title | <img src="https://github.com/H07000223/FlycoDialog_Master/blob/master/screenshot/action_sheet_2.png" width="250"> |[gif](https://github.com/H07000223/FlycoDialog_Master/blob/master/gif/preview_13.gif)
 
-##Built-in Popup
+## Built-in Popup
 |Popup|Description|ScreenShot|gif
 |:---:|:---:|:---:|:---:|
 | BubblePopup | BubblePopup | <img src="https://github.com/H07000223/FlycoDialog_Master/blob/master/screenshot/bubble_popup.png" width="250"> |[gif](https://github.com/H07000223/FlycoDialog_Master/blob/master/gif/preview_popup_1.gif)
@@ -127,7 +127,7 @@ An Android Dialog Lib simplify customization. Supprot 2.2+.
       }
   ```
   
-##Gradle
+## Gradle
 
 ```groovy
 dependencies{
@@ -149,13 +149,13 @@ dependencies{
 
 ```
 
-##Eclispe(no update)
+## Eclispe(no update)
 Eclipse Developers should include jars below into your project.
 *   [FlycoAnimation_Lib-v1.0.0.jar](https://github.com/H07000223/FlycoDialog_Master/blob/master/Jar/v1.0.0/FlycoAnimation_Lib-v1.0.0.jar)
 *   [FlycoDialog_Lib-v1.0.0.jar](https://github.com/H07000223/FlycoDialog_Master/blob/master/Jar/v1.0.0/FlycoDialog_Lib-v1.0.0.jar)
 *   [nineoldandroids-2.4.0.jar](https://github.com/H07000223/FlycoDialog_Master/blob/master/Jar/nineoldandroids-2.4.0.jar)
 
-##Thanks
+## Thanks
 *   [NineOldAndroids](https://github.com/JakeWharton/NineOldAndroids)
 *   [NiftyDialogEffects](https://github.com/sd6352051/NiftyDialogEffects)
 *   [AndroidViewAnimations](https://github.com/daimajia/AndroidViewAnimations)

--- a/README_CN.md
+++ b/README_CN.md
@@ -1,16 +1,16 @@
-#FlycoDialog-Master
+# FlycoDialog-Master
 [![Android Arsenal](https://img.shields.io/badge/Android%20Arsenal-FlycoDialog--Matser-green.svg?style=flat)](https://android-arsenal.com/details/1/2430)
 
 一个强大的Android对话框库,简化自定义对话框.支持2.2+.
 
-##特点
+## 特点
 - [内置Dialog,方便直接使用](#内置Dialog)
 - [丰富的内置动画库,方便直接使用](#丰富的内置动画库)
 - [支持快速自定义Dialog](#如何快速自定义Dialog)
 - [支持快速自定义Popup](#如何快速自定义Popup)
 - [支持自定义Dialog动画](#自定义Dialog动画)
 
-####[DemoApk下载](http://fir.im/mj9p)
+#### [DemoApk下载](http://fir.im/mj9p)
 
 ## <a name="内置Dialog"></a>内置Dialog
 |对话框|描述|截图|gif动画
@@ -29,7 +29,7 @@
 | ActionSheetDialog | 默认 | <img src="https://github.com/H07000223/FlycoDialog_Master/blob/master/screenshot/action_sheet_1.png" width="250"> |[gif](https://github.com/H07000223/FlycoDialog_Master/blob/master/gif/preview_12.gif)
 | ActionSheetDialog | 无标题 | <img src="https://github.com/H07000223/FlycoDialog_Master/blob/master/screenshot/action_sheet_2.png" width="250"> |[gif](https://github.com/H07000223/FlycoDialog_Master/blob/master/gif/preview_13.gif)
 
-##内置Popup
+## 内置Popup
 |弹窗|描述|截图|gif动画
 |:---:|:---:|:---:|:---:|
 | 弹窗 | 带三角箭头的提示弹窗 | <img src="https://github.com/H07000223/FlycoDialog_Master/blob/master/screenshot/bubble_popup.png" width="250"> |[gif](https://github.com/H07000223/FlycoDialog_Master/blob/master/gif/preview_popup_1.gif)
@@ -127,7 +127,7 @@
       }
   ```
   
-##Gradle
+## Gradle
 
 ```groovy
 dependencies{
@@ -150,13 +150,13 @@ dependencies{
 
 ```
 
-##Eclispe(不再维护更新)
+## Eclispe(不再维护更新)
 Eclipse Developers should include jars below into your project.
 *   [FlycoAnimation_Lib-v1.0.0.jar](https://github.com/H07000223/FlycoDialog_Master/blob/master/Jar/v1.0.0/FlycoAnimation_Lib-v1.0.0.jar)
 *   [FlycoDialog_Lib-v1.0.0.jar](https://github.com/H07000223/FlycoDialog_Master/blob/master/Jar/v1.0.0/FlycoDialog_Lib-v1.0.0.jar)
 *   [nineoldandroids-2.4.0.jar](https://github.com/H07000223/FlycoDialog_Master/blob/master/Jar/nineoldandroids-2.4.0.jar)
 
-##Thanks
+## Thanks
 *   [NineOldAndroids](https://github.com/JakeWharton/NineOldAndroids)
 *   [NiftyDialogEffects](https://github.com/sd6352051/NiftyDialogEffects)
 *   [AndroidViewAnimations](https://github.com/daimajia/AndroidViewAnimations)


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
